### PR TITLE
bug/10-fix_fetchBusinessSearch_image_url_returning_null_when_asObject_is_set_to_true

### DIFF
--- a/lib/models/business_endpoints/business_search.dart
+++ b/lib/models/business_endpoints/business_search.dart
@@ -135,7 +135,7 @@ class BusinessSearched {
       distance: map['distance'],
       id: map['id'],
       alias: map['alias'],
-      imageUrl: map['imageUrl'],
+      imageUrl: map['image_url'],
       location: Location.fromMap(map['location']),
       name: map['name'],
       phone: map['phone'],


### PR DESCRIPTION
### Issue
#10 
### Description
Fixed associated map['key'] definition in `business_search.dart`